### PR TITLE
test: add request error message test case

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-starter-web")
     compileOnly("org.springframework.boot:spring-boot-starter-webflux")
     compileOnly("org.springframework.boot:spring-boot-starter-security")
+    testImplementation("org.springframework.boot:spring-boot-starter-web")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
 publishing {
@@ -108,4 +110,4 @@ signing {
 }
 
 fun Project.findSecret(key: String, env: String): String? =
-    project.findProperty(key) as? String ?: System.getenv(env)
+        project.findProperty(key) as? String ?: System.getenv(env)

--- a/src/test/java/dev/ocpd/spring/problem/RequestMvcTest.kt
+++ b/src/test/java/dev/ocpd/spring/problem/RequestMvcTest.kt
@@ -1,0 +1,49 @@
+package dev.ocpd.spring.problem
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@AutoConfigureMockMvc
+@WebMvcTest(RequestTestController::class)
+class RequestMvcTest(@Autowired private val mockMvc: MockMvc) {
+
+    @Test
+    fun `should return 400 and custom error message when request body is invalid`() {
+        val request = """
+            {
+                "name": " "
+            }
+        """.trimIndent()
+        mockMvc.post("/api/test/request") {
+            contentType = MediaType.APPLICATION_JSON
+            content = request
+        }
+                .andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.detail") { value("name must be non-blank") }
+                }
+    }
+}
+
+@RestController
+class RequestTestController {
+
+    @PostMapping("/api/test/request")
+    fun withBodyRequest(@RequestBody request: RequestTest): String {
+        return request.name
+    }
+}
+
+data class RequestTest(val name: String) {
+    init {
+        require(name.isNotBlank()) { "name must be non-blank" }
+    }
+}

--- a/src/test/java/dev/ocpd/spring/problem/ServerApp.java
+++ b/src/test/java/dev/ocpd/spring/problem/ServerApp.java
@@ -1,0 +1,13 @@
+package dev.ocpd.spring.problem;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ServerApp {
+
+    public static void main(String[] args) {
+        var app = new SpringApplication(ServerApp.class);
+        app.run(args);
+    }
+}

--- a/src/test/java/dev/ocpd/spring/problem/errors/WebExceptionHandler.kt
+++ b/src/test/java/dev/ocpd/spring/problem/errors/WebExceptionHandler.kt
@@ -1,0 +1,37 @@
+package dev.ocpd.spring.problem.errors
+
+import dev.ocpd.spring.problem.servlet.GeneralAdviceTrait
+import org.apache.catalina.connector.ClientAbortException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+
+/*
+ * This overrides the existing ProblemDetailsExceptionHandler provided by Spring Boot.
+ *
+ * To ensure all unknown exceptions will be handled as a ProblemDetail response, we
+ * needed a catch-all exception handler that will capture all [Throwable]s. However,
+ * the ProblemDetailsExceptionHandler provided by Spring Boot by default has the lowest
+ * precedence, which means there's no guarantee that our catch-all exception handler will
+ * be called last therefore causing undesired behaviors. The root cause of this is that
+ * the [OrderComparator] will implicitly assign the lowest precedence to [Ordered] beans
+ * if no explicit order is otherwise specified.
+ * To solve this, we have to extend and override the default ProblemDetailsExceptionHandler
+ * so that all exception handlers are within a single class and the ordering is more predictable.
+ * Spring Boot will prioritize narrower exception handlers over broader ones if they are defined
+ * in the same class.
+ *
+ * Spring Boot is also in the process of unifying their built-in exceptions, so this class
+ * is more as a temporary workaround until the unification is complete.
+ * See:
+ * https://github.com/spring-projects/spring-boot/issues/19525
+ * https://github.com/spring-projects/spring-boot/issues/33885
+ */
+@RestControllerAdvice
+class WebExceptionHandler : ResponseEntityExceptionHandler(), GeneralAdviceTrait {
+
+    @ExceptionHandler(ClientAbortException::class)
+    fun handleClientAbortException(e: ClientAbortException) {
+        // Ignore
+    }
+}

--- a/src/test/java/dev/ocpd/spring/problem/errors/package-info.java
+++ b/src/test/java/dev/ocpd/spring/problem/errors/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package dev.ocpd.spring.problem.errors;
+
+import org.springframework.lang.NonNullApi;


### PR DESCRIPTION
Prove the error message returned from request is not the expected result:

- Pass in a string contain  `" "`
- The request is caught by `HttpMessageNotReadableException` and return `"Failed to read request"` message, not the customized error message we defined.